### PR TITLE
Update `/postcodes_by_settlement` logic

### DIFF
--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -9,7 +9,7 @@ info:
   description: Information System "Post" API
   termsOfService: http://swagger.io/terms/
   title: Information System "Post"
-  version: 0.3.8
+  version: 0.3.9
 tags:
   - name: Get Information
     description: Endpoints to get information

--- a/backend/models/post_office.go
+++ b/backend/models/post_office.go
@@ -59,6 +59,8 @@ func (po *PostOffice) GetSettlementByPostcode() (map[string]string, error) {
 	return settlementByPostcode, nil
 }
 
+// Return ONLY post offices with "Communication department" type
+
 func (po *PostOffice) GetPostcodesBySettlement() (map[string][]string, error) {
 	client := db.GetDB()
 	postOfficeCollection := client.Database("post").Collection("postOffices")
@@ -73,7 +75,7 @@ func (po *PostOffice) GetPostcodesBySettlement() (map[string][]string, error) {
 		{"address.settlement", 1},
 		{"_id", 0}}
 	opts := options.Find().SetProjection(projection)
-	cursor, err := postOfficeCollection.Find(ctx, bson.D{{}}, opts)
+	cursor, err := postOfficeCollection.Find(ctx, bson.D{{"type", "Отделение связи"}}, opts)
 	if err != nil {
 		return nil, fmt.Errorf("GetPostOffices: %v", err)
 	}


### PR DESCRIPTION
backend v0.3.9

API:
- `/postcodes_by_settlement` now return post offices only with "Communication department" type